### PR TITLE
Add markdown syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,26 +21,26 @@ Flux requires a browser which supports CSS3 transformations and has been built t
 
 # Usage
 Create HTML markup with the images you wish to use. You can also wrap images in a link if you need them to be clickable. For example:
-
+```html
 	<div id="slider">
 		<img src="img/avatar.jpg" alt="" />
 		<img src="img/ironman.jpg" alt="" title="Ironman Screenshot" />
 		<a href=""><img src="img/imagewithlink.jpg" alt="" /></a>
 		<img src="img/tron.jpg" alt="" />
 	</div>
-	
+```	
 Next instantiate Flux Slider:
-
+```javascript
 	$(function(){
 		window.myFlux = new flux.slider('#slider');
 	});
-	
+```
 Or, if you're using the provided jQuery widget then you can also do the following:
-	
+```javascript	
 	$(function(){
 		window.myFlux = $('#slider').flux();
 	});
-	
+```	
 *Note: If you plan to use the Zepto framework then the widget method won't work*
 
 ## A note on feature detection
@@ -93,23 +93,23 @@ The <flux.slider> constructor can also take an optional second parameter which i
 	The number of milliseconds to wait between image transitions
 	
 For example, to prevent autoplay and show a pagination control you would do the following:
-
+```javascript
 	$(function(){
 		window.myFlux = new flux.slider('#slider', {
 			autoplay: false,
 			pagination: true
 		});
 	});
-	
+```
 Or with the jQuery widget:
-
+```javascript
 	$(function(){
 		window.myFlux = $('#slider').flux({
 			autoplay: false,
 			pagination: true
 		});
 	});
-
+```
 ## flux.slider API
 
 The API functions work with both the native Javascript object and the jQuery widget. For example:
@@ -168,16 +168,16 @@ Flux provides a couple of mechanisms for this:
 #### `fluxTransitionEnd` Javascript Event
 
 After each transition, Flux dispatches a `fluxTransitionEnd` event. To listen for these events you can do the following:
-
+```javascript
 	$('#slider').bind('fluxTransitionEnd', function(event) {
 		var img = event.data.currentImage;
 		// Do something with img...
 	});
-
+```
 #### `onTransitionEnd` callback function
 	
 You can alternatively pass in a callback function as part of the configuration options when you instantiate Flux, e.g.
-
+```javascript
 	window.myFlux = $('#slider').flux({
 		autoplay: false,
 		pagination: true,
@@ -186,12 +186,12 @@ You can alternatively pass in a callback function as part of the configuration o
 			// Do something with img...
 		}
 	});
-	
+```
 # Writing custom transitions
 Writing your own custom transitions is easy, you just need to create an instance of a `flux.transition` object and pass in some callback functions to provide the custom behaviour you're looking for.
 
 Lets look at the built in **bars** transition as an example. The barebones definition of the transition looks like:
-
+```javascript
 	flux.transitions.bars = function(fluxslider, opts) {
 		return new flux.transition(fluxslider, $.extend({
 			barWidth: 60,
@@ -203,7 +203,7 @@ Lets look at the built in **bars** transition as an example. The barebones defin
 			}
 		}, opts));	
 	}
-
+```
 Here we add a new function to the `flux.transitions` namespace called **bars**. This function takes two parameters, a `flux.slider` object and an options key/value object. 
 
 *Note: Its currently not possible to pass options into transitions from the core flux.slider code but as this is on the list of things to add its a good idea to make sure the transitions can handle this when its implemented!*
@@ -225,7 +225,7 @@ All transition objects automatically have access to the following:
 Two functions are needed for the transition to operate, first is `setup`. This function is responsible for initialising the DOM before the transition runs. In the case of the bars transition this function creates a `div` for each bar and set the background image so that adjacent bars appear as a single image.
 
 The setup function should also initialise the CSS3 properties needed to enable a CSS transition.
-
+```javascript
 	setup: function() {
 		var barCount = Math.floor(this.slider.image1.width() / this.options.barWidth) + 1
 	
@@ -250,12 +250,12 @@ The setup function should also initialise the CSS3 properties needed to enable a
 			this.slider.image1.append(bar);
 		}
 	}
-
+```
 A helper function called `.css3()` has been created for convenience to automatically add vendor prefixes to CSS3 properties. Any properties that require prefixes should be added via this function rather than `.css()` as this ensures that transitions are cross-browser compatible.
 	
 ## execute()
 The `execute` function is where the CSS changes should be made, as transitions have already been initialised in `setup()` applying the end CSS property state should be all thats required:
-
+```javascript
 	execute: function() {
 		var _this = this;
 	
@@ -274,7 +274,7 @@ The `execute` function is where the CSS changes should be made, as transitions h
 			'transform': flux.browser.translate(0, height)
 		});
 	}
-	
+```
 Two further convenience functions have been used in this example. The first `.transitionEnd()` is a cross-browser event function to catch the 'transition end' event. In this example we want to be notified when the final bar as finished animating, this is how we know the transition is complete. We can then perform some custom code but its important to remember to call the transitions `finished()` function to ensure that the DOM is reset for the next transition.
 
 ## Transition writing guidelines
@@ -282,7 +282,7 @@ Two further convenience functions have been used in this example. The first `.tr
 Here are some guidelines for writing transitions if you'd like to have them considered for inclusion into the main distribution:
 
 - 	If the transition requires 3D transforms you must set the `requires3d` property to `true`. e.g.
-	
+```javascript	
 		flux.transitions.bars3d = function(fluxslider, opts) {
 			return new flux.transition(fluxslider, $.extend({
 				requires3d: true,
@@ -291,11 +291,11 @@ Here are some guidelines for writing transitions if you'd like to have them cons
 				}
 			}
 		};
-
+```
 - 	For delaying animations to specific bars/blocks/tiles use `-[webkit/moz/o]-transition-delay` rather than `setTimeout()`/`setInterval()`. This enables the GPU to handle the timing and makes for smoother transitions.
 
 - 	When using many new bars/blocks/tiles, add them to a container element off DOM and then add the container in one go, e.g.
-	
+```javascript	
 		var container = $('<div></div>');
 		
 		for(var i=0; i<10; i++) {
@@ -304,7 +304,7 @@ Here are some guidelines for writing transitions if you'd like to have them cons
 		}
 		
 		this.image.slider1.append(container);
-
+```
 # flux.browser
 
 `flux.browser` is an object designed to help determine browser support for CSS3 transitions.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Flux Slider
-Flux slider is a CSS3 animation based image transition framework, inspired in part by the fantastic [Nivo Slider](nivo.dev7studios.com) jQuery plugin.
+Flux slider is a CSS3 animation based image transition framework, inspired in part by the fantastic [Nivo Slider](http://nivo.dev7studios.com) jQuery plugin.
 
 Instead of the traditional Javascript timer based animations used by jQuery, Flux utilises the newer, more powerful CSS3 animation technology. Its in a fairly early/rough state at the moment but testing on the iPhone/iPad does appear to produce much smoother animations. Desktop performance (as with Nivo) is very smooth but the use of CSS3 enables us to produce some new effects that Nivo can’t, e.g. rotations.
 


### PR DESCRIPTION
This adds syntax-highlighted source code in README.md. No content has been changed.

I think it makes the docs significantly easier to read.
